### PR TITLE
pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,22 +30,27 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      # r-lib/actions v2 (setup-pandoc)
+      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
 
-      - uses: r-lib/actions/setup-r@v2
+      # r-lib/actions v2 (setup-r)
+      - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      # r-lib/actions v2 (setup-r-dependencies)
+      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - uses: r-lib/actions/check-r-package@v2
+      # r-lib/actions v2 (check-r-package)
+      - uses: r-lib/actions/check-r-package@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,15 +24,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      # r-lib/actions v2 (setup-pandoc)
+      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
 
-      - uses: r-lib/actions/setup-r@v2
+      # r-lib/actions v2 (setup-r)
+      - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      # r-lib/actions v2 (setup-r-dependencies)
+      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
@@ -43,7 +47,8 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        # JamesIves/github-pages-deploy-action v4.5.0
+        uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
         with:
           clean: false
           branch: gh-pages


### PR DESCRIPTION
Replace mutable version tags in both workflow files with immutable commit SHAs, with a comment above each step naming the original tag so future updates stay legible.

  actions/checkout                       v4     -> 34e1148
  r-lib/actions                          v2     -> 6f6e5bc
  JamesIves/github-pages-deploy-action   v4.5.0 -> 65b5dfd

Pinning to SHAs is GitHub's recommended hardening (see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and prevents a compromised tag from silently introducing malicious code into our CI runs.