### PR TITLE
Remove unneeded dependency on readtext and update ggplot name convention

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,9 +27,8 @@ Imports:
     quanteda.textstats,
     spacyr,
     stringr
-Suggests: 
+Suggests:
     knitr,
-    readtext,
     rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/R/create_corpus.R
+++ b/R/create_corpus.R
@@ -29,12 +29,21 @@ create_corpus <- function(path, encoding = "UTF-8") {
   }
 
   #### main function ####
-  corpus <- readtext::readtext(
-    file = paste0(path, "/*.txt"),
-    docvarsfrom = "filenames", docvarnames = c("author", "textname"),
-    encoding = encoding
-  ) |>
-    quanteda::corpus()
+  filepaths <- file.path(path, filenames)
+
+  texts <- sapply(filepaths, \(f) {
+    con <- file(f, encoding = encoding)
+    on.exit(close(con))
+    paste(readLines(con, warn = FALSE), collapse = "\n")
+  })
+  names(texts) <- filenames
+
+  parts <- stringr::str_match(filenames, "(.+)_(.+)\\.txt")
+
+  corpus <- quanteda::corpus(
+    texts,
+    docvars = data.frame(author = parts[, 2], textname = parts[, 3])
+  )
 
   return(corpus)
 }

--- a/tests/testthat/test-create_corpus.R
+++ b/tests/testthat/test-create_corpus.R
@@ -9,3 +9,25 @@ test_that("filename syntax check works", {
     "Some files do not follow the required syntax: abc2.txt, smithtext.txt"
   )
 })
+test_that("create_corpus preserves newlines within text files", {
+  # The on-disk fixtures in data/texts/ are all single-line, so they can't
+  # exercise newline preservation. Build a throwaway corpus directory with
+  # a multi-line file (including a blank line) and verify the loader
+  # round-trips the newlines into the corpus body.
+  tmp <- tempfile("create_corpus_newlines_")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  lines <- c(
+    "First paragraph.",
+    "",
+    "Second paragraph after a blank line.",
+    "Third line."
+  )
+  writeLines(lines, file.path(tmp, "alice_001.txt"))
+
+  body <- as.character(create_corpus(tmp))[[1]]
+
+  expect_equal(body, paste(lines, collapse = "\n"))
+  expect_true(grepl("\n\n", body, fixed = TRUE))
+})

--- a/tests/testthat/test-density_plot.R
+++ b/tests/testthat/test-density_plot.R
@@ -6,7 +6,7 @@ test_that("density plotting works", {
 
   p = density_plot(res, fake.q)
 
-  expect_true(ggplot2::is.ggplot(p))
+  expect_true(ggplot2::is_ggplot(p))
   expect_error(print(p), NA)
 
 })


### PR DESCRIPTION
The current code uses `readtext`, which has a dependency on `pdftools` (and therefore transitive dependency on `libpoppler-dev`), though the function it's used in is set to only read `.txt` files, so the default R `readlines()` is simpler and removes the need to install more dependencies in the system.

The current tests also confirm there are no regressions in behavior.

While I was here, I also updated the deprecated naming of `is.ggplot` to `is_ggplot`, as recommended in [the ggplot docs](https://ggplot2.tidyverse.org/reference/is_tests.html).

<img width="784" height="393" alt="Screenshot from 2026-04-25 15-12-15" src="https://github.com/user-attachments/assets/1a8f54fb-d1ca-4271-8f18-c7c5e64db26a" />
